### PR TITLE
Implementing screen space line thickness and optional anti aliasing

### DIFF
--- a/Unity Project/Dungeoneering/Assets/_Project/Shader/FlickerShader.shader
+++ b/Unity Project/Dungeoneering/Assets/_Project/Shader/FlickerShader.shader
@@ -3,9 +3,10 @@ Shader "Unlit/FlickerShader"
     Properties
     {
         _BaseColor("Color", Color) = (1,1,1,1)
-        _Thickness("Thickness", Float) = 0.1
+        _Thickness("Thickness", Float) = 5
         _Speed("Flicker Speed", Float) = 1
         _MinOpacity("Min Opacity", Float) = .1
+        [Toggle(_SMOOTH_EDGES_ON)] _SMOOTH_EDGES("Smooth line edges", Integer) = 1
     }
     SubShader
     {
@@ -19,6 +20,8 @@ Shader "Unlit/FlickerShader"
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
+
+            #pragma shader_feature_local _SMOOTH_EDGES_ON
 
             #include "UnityCG.cginc"
 
@@ -55,12 +58,16 @@ Shader "Unlit/FlickerShader"
             fixed4 frag (v2f i) : SV_Target
             {
                 fixed4 col = _BaseColor;
-                bool isEdge = i.uv.x < _Thickness || i.uv.x > (1 - _Thickness) || i.uv.y < _Thickness || i.uv.y > (1 - _Thickness);
-                if (!isEdge)
-                {
-                    col.a = _MinOpacity + _MinOpacity * flicker(_Speed);
-                }
-                return col;
+                float2 uvDerivative = fwidth(i.uv);
+                float2 fragmentThickness = uvDerivative * _Thickness;
+                float2 distFromEdge = 0.5 - abs(0.5 - i.uv);
+#if _SMOOTH_EDGES_ON
+                float2 edgeLineBlendAmount = smoothstep(fragmentThickness - uvDerivative, fragmentThickness, distFromEdge);
+#else
+                float2 edgeLineBlendAmount = step(fragmentThickness, distFromEdge);
+#endif
+                float flickerAlpha = _MinOpacity + _MinOpacity * flicker(_Speed);
+                return fixed4(col.rgb, lerp(col.a, flickerAlpha, min(edgeLineBlendAmount.x, edgeLineBlendAmount.y)));
             }
             ENDCG
         }


### PR DESCRIPTION
I made a few changes to demonstrate some nice shader functions and techniques.

In shaders, it's very often better to just do the math than to have branches. Performance testing is the only way to be sure, but that's generally the case. Some tools to help you with that are functions like step() and smoothstep(). They let you cut off a value if it is less than or greater than some other value without a branch in your code. step() just returns 0 or 1 based on whether one argument is less than the other, and smoothstep does a nice interpolation function called a hermite interpolation when the value is between the min and max arguments you provide, and 0 or 1 when it is outside that range,

The smoothing that I included is toggled on or off in the material, and Unity will compile a new variant of the shader when you toggle it, so there's no runtime branch, just conditional compilation. The smoothing is only noticeable if the map is roated to some non screen-pixel-aligned rotation, so it might not be something you'd want for this in practice if the camera rotation around that axis is locked, but it should demonstrate the approach.

Here's a little video of the smoothing being toggled:

https://github.com/user-attachments/assets/579e4602-b65a-492d-9415-400bbe33d680

