### PR TITLE
Fixing a bug in NormalizeScreenPoint

### DIFF
--- a/Unity Project/Dungeoneering/Assets/_Libs/CaptainCoder.Unity/src/RenderTextureMouseEvents.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/CaptainCoder.Unity/src/RenderTextureMouseEvents.cs
@@ -33,12 +33,14 @@ namespace CaptainCoder.Dungeoneering.Unity
         /// <returns></returns>    
         private Vector2 NormalizeScreenPoint(Vector2 screenPoint)
         {
-            RectTransform rect = (RectTransform)transform;
-            Vector3[] corners = {default, default, default, default};
-            rect.GetWorldCorners(corners);
-            Vector2 onScreenSize = new (corners[2].x - corners[0].x, corners[2].y - corners[0].y);
-            Vector2 scale = new (TargetTexture.width/onScreenSize.x, TargetTexture.height/onScreenSize.y);
-            return (screenPoint - (Vector2)corners[0])*scale;
+#if UNITY_EDITOR
+            // The simplified math in this method works because the canvas is in screen space overlay mode.
+            // If it weren't, we'd have to transform to world space through the camera
+            Debug.Assert(_parent.renderMode == RenderMode.ScreenSpaceOverlay);
+#endif
+	
+            RectTransform rectTransform = (RectTransform)transform;
+            return (Vector2)rectTransform.InverseTransformPoint(screenPoint) - rectTransform.rect.position;
         }
         
         private bool TryGetWorldPoint(Vector2 screenPoint, out Vector3 worldPoint)


### PR DESCRIPTION
This was intended to address #8 , but I just saw that you also made a commit fixing this when I was trying to merge back in, so I suppose you won't need this anymore. But I did take a different approach of doing the transformation through the Transform itself, which might be interesting to you.

There's also a built in way to solve this that optionally takes into account the camera for non-screen space overlay canvases, and that would look like the following. I didn't use it because it's a fair bit more expensive, and we can probably assume screen space overlay for the canvas here.
```cs
private Vector2 NormalizeScreenPoint(Vector2 screenPoint)
{
	RectTransform rectTransform = (RectTransform)transform;
	Debug.Assert(RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, screenPoint, null, out var transformed));
	return transformed - rectTransform.rect.position;
}
```