### PR TITLE
 Adding in a matrix to transform from screen space to texture space

### DIFF
--- a/Unity Project/Dungeoneering/Assets/_Libs/CaptainCoder.Unity/src/RenderTextureMouseEvents.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/CaptainCoder.Unity/src/RenderTextureMouseEvents.cs
@@ -9,7 +9,6 @@ namespace CaptainCoder.Unity
         public Camera TargetCamera;
         public RenderTexture TargetTexture;
         private Matrix4x4 screenToTextureMatrix = Matrix4x4.identity;
-        private bool isTransformDirty = true;
         
         [field: SerializeField]
         public UnityEvent<ScrollData> OnScrollEvent { get; private set; } = new();
@@ -24,10 +23,10 @@ namespace CaptainCoder.Unity
         
         private Matrix4x4 ScreenToTextureMatrix {
             get {
-                if (!transform.hasChanged & !isTransformDirty)
+                if (!transform.hasChanged)
                     return screenToTextureMatrix;
 
-                transform.hasChanged = isTransformDirty = false;
+                transform.hasChanged = false;
                 RectTransform rectTransform = (RectTransform)transform;
                 Rect rect = rectTransform.rect;
                 Vector3 onScreenSize = rectTransform.TransformVector(rect.size);
@@ -44,7 +43,7 @@ namespace CaptainCoder.Unity
         private void Start() => OnRectTransformDimensionsChange();
 
         private void OnRectTransformDimensionsChange() {
-            isTransformDirty = true;
+            transform.hasChanged = true;
             
             RectTransform rect = (RectTransform)transform;
             if (_size != rect.rect.size)


### PR DESCRIPTION
This version recalculates the matrix fields after Unity sends the OnRectTransformDimensionsChange message or when the Transform changes and then there's a click to handle. That way, when the transformation is needed to handle a click, it's a single matrix multiplication. That gets rid of the array allocation and 3 of the matrix multiplications that happen to get the corners in screen space. I also moved the code that was re-rendering the texture from Update to OnRectTransformDimensionsChange, if that seems ok.

No worries if you're not into this approach, though.