### PR TITLE
Adding in graph traversal selection for walls on double click

### DIFF
--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/DungeonEditorSelectionData.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/DungeonEditorSelectionData.cs
@@ -40,11 +40,17 @@ namespace CaptainCoder.Dungeoneering.Unity
             OnWallsChanged.Invoke(_selectedWalls);
         }
 
-        public void SetWallSelection(params DungeonWallController[] wall)
+        public void SetWallSelection(params DungeonWallController[] walls) => SetWallSelection((IEnumerable<DungeonWallController>)walls);
+        
+        public void SetWallSelection(IEnumerable<DungeonWallController> walls)
         {
-            ClearTiles();
             _selectedWalls.Clear();
-            _selectedWalls.UnionWith(wall);
+            AddWallSelection(walls);
+        }
+
+        public void AddWallSelection(IEnumerable<DungeonWallController> walls) {
+            ClearTiles();
+            _selectedWalls.UnionWith(walls);
             OnWallsChanged.Invoke(_selectedWalls);
         }
 
@@ -61,7 +67,7 @@ namespace CaptainCoder.Dungeoneering.Unity
             _selectedWalls.Clear();
             OnWallsChanged.Invoke(_selectedWalls);
         }
-
+        
         public void ToggleTileSelected(DungeonTile tile)
         {
             if (_selectedTiles.Contains(tile)) { _selectedTiles.Remove(tile); }

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/EditorContextController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/EditorContextController.cs
@@ -6,8 +6,10 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 namespace CaptainCoder.Dungeoneering.Unity
 {
-    public class EditorContextController : MonoBehaviour
-    {
+    public class EditorContextController : MonoBehaviour {
+        private const int FACING_ORIENTATION_BIT = 1;
+        private const int FACING_DIRECTION_BIT = 2;
+        
         [field: SerializeField]
         public DungeonEditorSelectionData SelectionData { get; private set; }
         [field: SerializeField]
@@ -16,6 +18,8 @@ namespace CaptainCoder.Dungeoneering.Unity
         private DungeonController _dungeonController;
         private float _lastClick;
         private DungeonTile _lastClicked;
+        private DungeonWallController _lastClickedWall;
+        private static readonly Facing[] _facings = { Facing.North, Facing.East, Facing.South, Facing.West };
 
         public void Click(DungeonTile clicked)
         {
@@ -39,11 +43,21 @@ namespace CaptainCoder.Dungeoneering.Unity
             }
             _lastClick = time;
             _lastClicked = clicked;
+            _lastClickedWall = null;
         }
 
-        public void Click(DungeonWallController clicked)
-        {
-            if (Keyboard.current.shiftKey.isPressed)
+        public void Click(DungeonWallController clicked) {
+            float time = Time.time;
+            bool isDoubleClick = _lastClickedWall == clicked && time - _lastClick <= DoubleClickTime;
+            if (isDoubleClick && Keyboard.current.shiftKey.isPressed)
+            {
+                SelectionData.AddWallSelection(GetConnectedWalls(clicked));
+            }
+            else if (isDoubleClick)
+            {
+                SelectionData.SetWallSelection(GetConnectedWalls(clicked));
+            }
+            else if (Keyboard.current.shiftKey.isPressed)
             {
                 SelectionData.ToggleWallSelected(clicked);
             }
@@ -51,31 +65,108 @@ namespace CaptainCoder.Dungeoneering.Unity
             {
                 SelectionData.SetWallSelection(clicked);
             }
-
+            _lastClick = time;
+            _lastClicked = null;
+            _lastClickedWall = clicked;
         }
 
         private IEnumerable<DungeonTile> SelectRoom(DungeonTile start)
         {
             int maxSelect = 1000;
-            Facing[] facings = { Facing.North, Facing.East, Facing.South, Facing.West };
             Dungeon d = start.Dungeon;
             HashSet<Position> allTiles = new() { start.Position };
             Queue<Position> queue = new();
             queue.Enqueue(start.Position);
             while (queue.TryDequeue(out Position position) && allTiles.Count < maxSelect)
             {
-                var neighbors = facings
+                var neighbors = _facings
                     .Where(f => d.Walls.GetWall(position, f) == WallType.None)
                     .Select(position.Step);
 
                 foreach (Position neighbor in neighbors)
                 {
-                    if (allTiles.Contains(neighbor)) { continue; }
-                    allTiles.Add(neighbor);
-                    queue.Enqueue(neighbor);
+                    if (allTiles.Add(neighbor))
+                        queue.Enqueue(neighbor);
                 }
             }
             return allTiles.Select(_dungeonController.GetDungeonTile);
+        }
+
+        private (DungeonWallController wall, Facing newIncomingSide) GetNextWall(DungeonWallController wall, Facing incomingSide)
+        {
+#if UNITY_EDITOR
+            Debug.Assert(wall.enabled);
+            // For vertical walls, the incoming side should be horizontal, and vice versa
+            Debug.Assert(((int)(wall.Facing ^ incomingSide) & FACING_ORIENTATION_BIT) == FACING_ORIENTATION_BIT);
+#endif
+
+            DungeonTile tile = wall.Parent;
+            if (tile == null) {
+                Debug.LogError("No parent tile found!");
+                return default;
+            }
+            
+            Facing exitSide = (Facing)((int)incomingSide ^ FACING_DIRECTION_BIT);
+            
+            // First check for the next wall as a turn in the current tile
+            DungeonWallController candidate = tile[exitSide];
+            
+            if (candidate.isActiveAndEnabled)
+                return (candidate, wall.Facing);
+            
+            // Next check for a matching continuation in the neighboring tile
+            Position exitSidePosition = wall.Parent.Position.Step(exitSide);
+            if (_dungeonController.TryGetDungeonTile(exitSidePosition, out DungeonTile neighborTile))
+            {
+                candidate = neighborTile[wall.Facing];
+                if (candidate.isActiveAndEnabled)
+                    return (candidate, incomingSide);
+            }
+            
+            // Next check for a connection through the sibling wall
+            if (_dungeonController.TryGetDungeonTile(exitSidePosition.Step(wall.Facing), out neighborTile))
+            {
+                candidate = neighborTile[incomingSide];
+                if (candidate.isActiveAndEnabled)
+                    return (candidate, (Facing)((int)wall.Facing ^ FACING_DIRECTION_BIT));
+            }
+            
+            // Finally, check for this wall's sibling
+            if (_dungeonController.TryGetDungeonTile(wall.Parent.Position.Step(wall.Facing), out neighborTile))
+            {
+                Facing reversedFacing = (Facing)((int)wall.Facing ^ FACING_DIRECTION_BIT);
+                candidate = neighborTile[reversedFacing];
+                if (candidate.isActiveAndEnabled)
+                    return (candidate, exitSide);
+            }
+            
+            // This appears to be a terminal node, so a wall segment on the map border with no connection
+            return default;
+        }
+        
+        private IEnumerable<DungeonWallController> GetConnectedWalls(DungeonWallController start)
+        {
+            yield return start;
+            
+            Facing initialIncoming = (Facing)((int)start.Facing ^ FACING_ORIENTATION_BIT);
+            var (curr, dir) = GetNextWall(start, initialIncoming);
+            while (curr != null && curr != start) {
+                yield return curr;
+                (curr, dir) = GetNextWall(curr, dir);
+            }
+
+            if (curr != null)
+                yield break;
+            
+            // If curr became null, that should mean that we ran into a terminal node (or some unknown condition),
+            // meaning there's a map edge tile without a wall at the border of the map. If that happens, continue the
+            // search in the opposite direction from the start
+            Facing reversedInitialIncoming = (Facing)((int)initialIncoming ^ FACING_DIRECTION_BIT);
+            (curr, dir) = GetNextWall(start, reversedInitialIncoming);
+            while (curr != null && curr != start) {
+                yield return curr;
+                (curr, dir) = GetNextWall(curr, dir);
+            }
         }
     }
 }

--- a/Unity Project/Dungeoneering/Assets/_Libs/MapGenerator/src/DungeonController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/MapGenerator/src/DungeonController.cs
@@ -84,6 +84,7 @@ namespace CaptainCoder.Dungeoneering.DungeonMap.Unity
         }
 
         public DungeonTile GetDungeonTile(Position position) => _tiles[position];
+        public bool TryGetDungeonTile(Position position, out DungeonTile tile) => _tiles.TryGetValue(position, out tile);
 
         void OnEnable()
         {

--- a/Unity Project/Dungeoneering/Assets/_Libs/MapGenerator/src/DungeonTile.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/MapGenerator/src/DungeonTile.cs
@@ -28,6 +28,18 @@ namespace CaptainCoder.Dungeoneering.DungeonMap.Unity
         [field: SerializeField]
         public MeshRenderer FloorTile { get; private set; } = default!;
 
+        public DungeonWallController this[Facing facing] {
+            get {
+                return facing switch {
+                    Facing.North => NorthWall,
+                    Facing.East => EastWall,
+                    Facing.South => SouthWall,
+                    Facing.West => WestWall,
+                    _ => throw new ArgumentOutOfRangeException(nameof(facing), facing, null),
+                };
+            }
+        }
+
         public string FloorTextureName => Dungeon.TileTextures.GetTileTextureName(Position);
         public void Click() => OnClicked.Invoke(this);
 


### PR DESCRIPTION
I think I made this about as efficient as it can be given the nature of the problem and the various look-ups required to traverse an edge. One problem I ran into is that, at least on my machine, in the editor, in debug, if there are many walls already selected, adding more can fail because the initial, single click takes longer than the allowed double click time of 0.2. There's plenty of ways around that, though. There's also a bit of code that probably belongs in an extension method on `Facing`, but I wasn't 100% sure where to put that, so we can refactor it whenever.

closes #30 