### PR TITLE
Clearing the selection cache in the selection controllers on dungeon load

### DIFF
--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedTilesController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedTilesController.cs
@@ -3,16 +3,14 @@ using System.Collections.Generic;
 using CaptainCoder.Dungeoneering.DungeonMap.Unity;
 
 using UnityEngine;
+
 namespace CaptainCoder.Dungeoneering.Unity.Editor
 {
     public class SelectedTilesController : MonoBehaviour
     {
-        [field: SerializeField]
-        public DungeonEditorSelectionData Selected { get; private set; }
-        [field: SerializeField]
-        public GameObject SelectionIndicatorPrefab { get; private set; }
-        [field: SerializeField]
-        public Transform IndicatorContainer { get; private set; }
+        [field: SerializeField] public DungeonEditorSelectionData Selected { get; private set; }
+        [field: SerializeField] public GameObject SelectionIndicatorPrefab { get; private set; }
+        [field: SerializeField] public Transform IndicatorContainer { get; private set; }
         private HashSet<DungeonTile> _selectedTiles = new();
         private HashSet<DungeonTile> _altSelectedTiles = new();
 
@@ -35,14 +33,22 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
                 tile.IsSelected = true;
                 _altSelectedTiles.Add(tile);
             }
-            
+
             foreach (var tile in _selectedTiles)
             {
                 if (!_altSelectedTiles.Contains(tile))
                     tile.IsSelected = false;
             }
+
             (_altSelectedTiles, _selectedTiles) = (_selectedTiles, _altSelectedTiles);
             _altSelectedTiles.Clear();
+        }
+
+        public void HandleDungeonChanged(DungeonData dungeon)
+        {
+            // Assuming this event only happens when a new dungeon is loaded.
+            // If that changes, we'll need to do some checking/updating
+            _selectedTiles.Clear();
         }
     }
 }

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedWallsController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedWallsController.cs
@@ -3,14 +3,13 @@ using System.Collections.Generic;
 using CaptainCoder.Dungeoneering.DungeonMap.Unity;
 
 using UnityEngine;
+
 namespace CaptainCoder.Dungeoneering.Unity.Editor
 {
     public class SelectedWallsController : MonoBehaviour
     {
-        [field: SerializeField]
-        public DungeonEditorSelectionData Selected { get; private set; }
-        [field: SerializeField]
-        public Transform IndicatorContainer { get; private set; }
+        [field: SerializeField] public DungeonEditorSelectionData Selected { get; private set; }
+        [field: SerializeField] public Transform IndicatorContainer { get; private set; }
         private HashSet<DungeonWallController> _selectedWalls = new();
         private HashSet<DungeonWallController> _altSelectedWalls = new();
 
@@ -21,10 +20,11 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
 
         void OnDisable()
         {
-            Selected.AddListener(HandleSelectionChanged);
+            Selected.RemoveListener(HandleSelectionChanged);
         }
 
         private void HandleSelectionChanged(SelectionChangedData data) => HandleSelectionChanged(data.SelectedWalls);
+
         private void HandleSelectionChanged(IEnumerable<DungeonWallController> newWalls)
         {
             foreach (var wall in newWalls)
@@ -32,14 +32,22 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
                 wall.IsSelected = true;
                 _altSelectedWalls.Add(wall);
             }
-            
+
             foreach (var wall in _selectedWalls)
             {
                 if (!_altSelectedWalls.Contains(wall))
                     wall.IsSelected = false;
             }
+
             (_altSelectedWalls, _selectedWalls) = (_selectedWalls, _altSelectedWalls);
             _altSelectedWalls.Clear();
+        }
+
+        public void HandleDungeonChanged(DungeonData dungeon)
+        {
+            // Assuming this event only happens when a new dungeon is loaded.
+            // If that changes, we'll need to do some checking/updating 
+            _selectedWalls.Clear();
         }
     }
 }

--- a/Unity Project/Dungeoneering/Assets/_Project/Scenes/DungeonEditor.unity
+++ b/Unity Project/Dungeoneering/Assets/_Project/Scenes/DungeonEditor.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c20d5e02bfa2d056533c33b578382f6807b9ddc39a48edd08e4ffbceee9531b9
-size 344990
+oid sha256:c7bf08a41ead275df5845edf73c8c71abef72b52f02a25a460ce7dc52f054479
+size 345997


### PR DESCRIPTION
Also fixed a bug where `SelectedWallsController` was accidentally re-adding an event listener in `OnDisable`