### PR TITLE
164 dungeoneditorselectiondata should use tilereference rather than dungeontile

### DIFF
--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/DungeonEditorSelectionData.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/DungeonEditorSelectionData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using CaptainCoder.Dungeoneering.DungeonMap.Unity;
 
 using UnityEngine;
-using UnityEngine.Events;
+
 namespace CaptainCoder.Dungeoneering.Unity
 {
     [CreateAssetMenu(menuName = "DC/SelectionData")]
@@ -15,15 +15,19 @@ namespace CaptainCoder.Dungeoneering.Unity
         private readonly HashSet<DungeonWallController> _walls = new();
         private ReadOnlySetView<DungeonWallController> _cachedWalls;
         public ReadOnlySetView<DungeonWallController> Walls => _cachedWalls ??= new(_walls);
-        private readonly UnityEvent<SelectionChangedEvent> _onDataChanged = new();
+        private System.Action<SelectionChangedEvent> _onDataChanged;
         private SelectionChangedEvent _changes;
 
-        public void AddListener(UnityAction<SelectionChangedEvent> onChange) => _onDataChanged.AddListener(onChange);
-        public void RemoveListener(UnityAction<SelectionChangedEvent> onChange) => _onDataChanged.RemoveListener(onChange);
+        public void AddObserver(System.Action<SelectionChangedEvent> onChange)
+        {
+            _onDataChanged += onChange;
+            onChange.Invoke(_changes ??= new SelectionChanged(Tiles, Walls));
+        }
+        public void RemoveObserver(System.Action<SelectionChangedEvent> onChange) => _onDataChanged -= onChange;
         private void Notify()
         {
             _changes ??= new SelectionChanged(Tiles, Walls);
-            _onDataChanged.Invoke(_changes);
+            _onDataChanged?.Invoke(_changes);
         }
 
         public void ToggleWallSelected(DungeonWallController wall)
@@ -70,7 +74,7 @@ namespace CaptainCoder.Dungeoneering.Unity
         protected override void OnExitPlayMode()
         {
             base.OnExitPlayMode();
-            _onDataChanged.RemoveAllListeners();
+            _onDataChanged = null;
             _walls.Clear();
             _selectedTiles.Clear();
         }

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/DungeonEditorSelectionData.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/DungeonEditorSelectionData.cs
@@ -15,14 +15,14 @@ namespace CaptainCoder.Dungeoneering.Unity
         private readonly HashSet<DungeonWallController> _walls = new();
         private ReadOnlySetView<DungeonWallController> _cachedWalls;
         public ReadOnlySetView<DungeonWallController> Walls => _cachedWalls ??= new(_walls);
-        private readonly UnityEvent<SelectionChangedData> _onDataChanged = new();
-        private SelectionChangedData _changes;
+        private readonly UnityEvent<SelectionChangedEvent> _onDataChanged = new();
+        private SelectionChangedEvent _changes;
 
-        public void AddListener(UnityAction<SelectionChangedData> onChange) => _onDataChanged.AddListener(onChange);
-        public void RemoveListener(UnityAction<SelectionChangedData> onChange) => _onDataChanged.RemoveListener(onChange);
+        public void AddListener(UnityAction<SelectionChangedEvent> onChange) => _onDataChanged.AddListener(onChange);
+        public void RemoveListener(UnityAction<SelectionChangedEvent> onChange) => _onDataChanged.RemoveListener(onChange);
         private void Notify()
         {
-            _changes ??= new SelectionChangedData(this);
+            _changes ??= new SelectionChanged(Tiles, Walls);
             _onDataChanged.Invoke(_changes);
         }
 
@@ -75,12 +75,5 @@ namespace CaptainCoder.Dungeoneering.Unity
             _selectedTiles.Clear();
         }
 
-    }
-
-    public class SelectionChangedData
-    {
-        public readonly ReadOnlySetView<DungeonTile> SelectedTiles;
-        public readonly ReadOnlySetView<DungeonWallController> SelectedWalls;
-        public SelectionChangedData(DungeonEditorSelectionData data) => (SelectedTiles, SelectedWalls) = (data.Tiles, data.Walls);
     }
 }

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/IsExternalInit.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/IsExternalInit.cs
@@ -1,0 +1,3 @@
+namespace System.Runtime.CompilerServices;
+// This is necessary to use record types in Unity projects
+internal static class IsExternalInit { }

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/IsExternalInit.cs.meta
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/IsExternalInit.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cfb5b7bcde914c146acb20284a49adf6

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedTilesController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedTilesController.cs
@@ -18,13 +18,13 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
         void OnEnable()
         {
             _dungeonCrawlerData.AddObserver(HandleDungeonChanged);
-            Selected.AddListener(HandleSelectionChanged);
+            Selected.AddObserver(HandleSelectionChanged);
         }
 
         void OnDisable()
         {
             _dungeonCrawlerData.RemoveObserver(HandleDungeonChanged);
-            Selected.RemoveListener(HandleSelectionChanged);
+            Selected.RemoveObserver(HandleSelectionChanged);
         }
 
         private void HandleSelectionChanged(SelectionChangedEvent @event)

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedTilesController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedTilesController.cs
@@ -27,7 +27,13 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
             Selected.RemoveListener(HandleSelectionChanged);
         }
 
-        private void HandleSelectionChanged(SelectionChangedData changes) => HandleSelectionChanged(changes.SelectedTiles);
+        private void HandleSelectionChanged(SelectionChangedEvent @event)
+        {
+            if (@event is SelectionChanged changes)
+            {
+                HandleSelectionChanged(changes.Tiles);
+            }
+        }
 
         private void HandleSelectionChanged(ReadOnlySetView<DungeonTile> tiles)
         {

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedWallsController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedWallsController.cs
@@ -27,7 +27,13 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
             Selected.RemoveListener(HandleSelectionChanged);
         }
 
-        private void HandleSelectionChanged(SelectionChangedData data) => HandleSelectionChanged(data.SelectedWalls);
+        private void HandleSelectionChanged(SelectionChangedEvent data)
+        {
+            if (data is SelectionChanged selection)
+            {
+                HandleSelectionChanged(selection.Walls);
+            }
+        }
 
         private void HandleSelectionChanged(IEnumerable<DungeonWallController> newWalls)
         {

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedWallsController.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectedWallsController.cs
@@ -18,13 +18,13 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
         void OnEnable()
         {
             _dungeonCrawlerData.AddObserver(HandleDungeonChanged);
-            Selected.AddListener(HandleSelectionChanged);
+            Selected.AddObserver(HandleSelectionChanged);
         }
 
         void OnDisable()
         {
             _dungeonCrawlerData.RemoveObserver(HandleDungeonChanged);
-            Selected.RemoveListener(HandleSelectionChanged);
+            Selected.RemoveObserver(HandleSelectionChanged);
         }
 
         private void HandleSelectionChanged(SelectionChangedEvent data)

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionChangedEvent.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionChangedEvent.cs
@@ -1,0 +1,5 @@
+using CaptainCoder.Dungeoneering.DungeonMap.Unity;
+
+namespace CaptainCoder.Dungeoneering.Unity;
+public abstract record class SelectionChangedEvent;
+public sealed record class SelectionChanged(ReadOnlySetView<DungeonTile> Tiles, ReadOnlySetView<DungeonWallController> Walls) : SelectionChangedEvent;

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionChangedEvent.cs.meta
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionChangedEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7230e8748a43bfd419248effae27ff11

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionInfoPanel.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionInfoPanel.cs
@@ -36,14 +36,14 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
         void OnEnable()
         {
             _dungeonCrawlerData.AddObserver(HandleTilesChanged);
-            _selection.AddListener(HandleSelectionChanged);
+            _selection.AddObserver(HandleSelectionChanged);
             RenderInfo(_selection.Tiles, _selection.Walls);
         }
 
         void OnDisable()
         {
             _dungeonCrawlerData.RemoveObserver(HandleTilesChanged);
-            _selection.RemoveListener(HandleSelectionChanged);
+            _selection.RemoveObserver(HandleSelectionChanged);
         }
 
         private void HandleSelectionChanged(SelectionChangedEvent @event)

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionInfoPanel.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionInfoPanel.cs
@@ -46,7 +46,13 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
             _selection.RemoveListener(HandleSelectionChanged);
         }
 
-        private void HandleSelectionChanged(SelectionChangedData changes) => RenderInfo(changes.SelectedTiles, changes.SelectedWalls);
+        private void HandleSelectionChanged(SelectionChangedEvent @event)
+        {
+            if (@event is SelectionChanged selection)
+            {
+                RenderInfo(selection.Tiles, selection.Walls);
+            }
+        }
 
         private void RenderInfo(ISet<DungeonTile> tiles, ISet<DungeonWallController> walls)
         {

--- a/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionInfoPanel.cs
+++ b/Unity Project/Dungeoneering/Assets/_Libs/DungeonCrawler.Unity.Editor/src/SelectionInfoPanel.cs
@@ -37,7 +37,6 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
         {
             _dungeonCrawlerData.AddObserver(HandleTilesChanged);
             _selection.AddObserver(HandleSelectionChanged);
-            RenderInfo(_selection.Tiles, _selection.Walls);
         }
 
         void OnDisable()
@@ -54,18 +53,21 @@ namespace CaptainCoder.Dungeoneering.Unity.Editor
             }
         }
 
-        private void RenderInfo(ISet<DungeonTile> tiles, ISet<DungeonWallController> walls)
+        private void RenderTileInfo(ISet<DungeonTile> tiles)
         {
-            _wallSelectionData.CountWalls(tiles, walls);
-            _content.SetActive(true);
-
             (string tileTextureName, TextureReference tileTexture) = TextureLabel(tiles);
             _tilesLabel.Label.text = $"{tiles.Count()} Tiles: {tileTextureName}";
             _tilesLabel.Button.Texture = tileTexture;
+        }
 
+        private void RenderInfo(ISet<DungeonTile> tiles, ISet<DungeonWallController> walls)
+        {
+            _wallSelectionData.CountWalls(tiles, walls);
+            RenderTileInfo(tiles);
             UpdateLabel(_wallsLabel, "Walls", _wallSelectionData.Solid);
             UpdateLabel(_doorsLabel, "Doors", _wallSelectionData.Doors);
             UpdateLabel(_secretDoorLabel, "Secret Doors", _wallSelectionData.SecretDoors);
+            _content.SetActive(true);
         }
 
         private void UpdateLabel(TextureLabelController label, string name, ISet<(Position, Facing)> walls)


### PR DESCRIPTION
- **refactor: Extract SelectionChangedEvent**
- **refactor: Replace UnityEvent with C# event**
- **refactor: Refactor for readablity.**
